### PR TITLE
Added default CC backlinks to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Example:
 - Next.js Documentation - learn about Next.js features and API.
 - Learn Next.js - an interactive Next.js tutorial.
 
+**ConfigCat** also supports many other frameworks and languages. Check out the full list of supported SDKs [here](https://configcat.com/docs/sdk-reference/overview/)
+
+Keep up with ConfigCat on [Twitter](https://twitter.com/configcat), [Facebook](https://www.facebook.com/configcat), [LinkedIn](https://www.linkedin.com/company/configcat/), and [GitHub](https://github.com/configcat).
+
 ## Author
 [Your Name](https://github.com/your_name)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Example:
 - Next.js Documentation - learn about Next.js features and API.
 - Learn Next.js - an interactive Next.js tutorial.
 
-**ConfigCat** also supports many other frameworks and languages. Check out the full list of supported SDKs [here](https://configcat.com/docs/sdk-reference/overview/)
+[**ConfigCat**](https://configcat.com) also supports many other frameworks and languages. Check out the full list of supported SDKs [here](https://configcat.com/docs/sdk-reference/overview/)
 
 Keep up with ConfigCat on [Twitter](https://twitter.com/configcat), [Facebook](https://www.facebook.com/configcat), [LinkedIn](https://www.linkedin.com/company/configcat/), and [GitHub](https://github.com/configcat).
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Example:
 
 [**ConfigCat**](https://configcat.com) also supports many other frameworks and languages. Check out the full list of supported SDKs [here](https://configcat.com/docs/sdk-reference/overview/)
 
+You can also explore other code samples for various languages, frameworks, and topics here in the [ConfigCat labs](https://github.com/configcat-labs) on GitHub.
+
 Keep up with ConfigCat on [Twitter](https://twitter.com/configcat), [Facebook](https://www.facebook.com/configcat), [LinkedIn](https://www.linkedin.com/company/configcat/), and [GitHub](https://github.com/configcat).
 
 ## Author


### PR DESCRIPTION
ConfigCat's resources should also fall under the "Learn more" section, as they'll by default be used in any sample app. This is also a good backlink opportunity.